### PR TITLE
Added static build of opencv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,41 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libclang-dev libopencv-dev
+        sudo apt-get install -y libclang-dev build-essential cmake git pkg-config
+
+    - name: Install OpenCV dependencies
+      run: |
+        git clone --branch 4.8.1 --depth 1 https://github.com/opencv/opencv.git
+        cd opencv
+        mkdir build && cd build
+        cmake .. \
+          -DBUILD_SHARED_LIBS=OFF \
+          -DBUILD_TESTS=OFF \
+          -DBUILD_PERF_TESTS=OFF \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_opencv_core=ON \
+          -DBUILD_opencv_imgproc=ON \
+          -DBUILD_opencv_highgui=OFF \
+          -DBUILD_opencv_video=OFF \
+          -DBUILD_opencv_features2d=OFF \
+          -DBUILD_opencv_python_bindings_generator=OFF \
+          -DBUILD_opencv_gapi=OFF \
+          -DBUILD_opencv_calib3d=OFF \
+          -DBUILD_opencv_imgcodecs=OFF \
+          -DBUILD_opencv_ml=OFF \
+          -DBUILD_opencv_photo=OFF \
+          -DBUILD_opencv_dnn=OFF \
+          -DBUILD_JPEG=OFF \
+          -DBUILD_PNG=OFF \
+          -DBUILD_TIFF=OFF \
+          -DBUILD_WEBP=OFF \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/opt/opencv-static \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+          -DOPENCV_GENERATE_PKGCONFIG=ON
+        make -j$(nproc)
+        make install
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -151,6 +185,7 @@ jobs:
         poetry build --format wheel
       env:
         POETRY_VIRTUALENVS_CREATE: false
+        RUST_STARTRACKER_OPENCV_LINK_STATIC: 1
 
     - name: Upload wheel
       run: |

--- a/build_script.py
+++ b/build_script.py
@@ -3,8 +3,10 @@
 This script is automatically run when the pyproject is installed.
 """
 
+import argparse
 import csv
 import io
+import os
 import pathlib
 import shutil
 import subprocess
@@ -99,7 +101,7 @@ def download_hipparcos_data(output_file: pathlib.Path) -> None:
     print(f"Saved to: {output_file}")
 
 
-def build_script() -> None:
+def build_script(*, static: bool = False) -> None:
     """Build rust backend and move shared library to correct folder."""
     cwd = pathlib.Path(__file__).parent.expanduser().absolute()
 
@@ -111,11 +113,19 @@ def build_script() -> None:
     if not hipparcos_file.exists():
         download_hipparcos_data(hipparcos_file)
 
+    env = dict(**os.environ)
+    if static:
+        env["OPENCV_LINK_STATIC"] = "1"
+        env["OPENCV_INCLUDE_PATHS"] = "/opt/opencv-static/include/opencv4"
+        env["OPENCV_LIBRARY_PATHS"] = "/opt/opencv-static/lib"
+        env["PKG_CONFIG_PATH"] = "/opt/opencv-static/lib/pkgconfig"
+
     subprocess.check_call(  # noqa: S603
         ["cargo", "build", "--release", "--features", "improc,gaia,hipparcos"],  # noqa: S607
         cwd=cwd,
         stdout=None,
         stderr=None,
+        env=env,
     )
     shutil.copy(
         cwd / "target/release/libruststartracker.so", cwd / "ruststartracker/libruststartracker.so"
@@ -123,4 +133,11 @@ def build_script() -> None:
 
 
 if __name__ == "__main__":
-    build_script()
+    parser = argparse.ArgumentParser(description="Build the StarTracker project.")
+    parser.add_argument(
+        "--static", action="store_true", help="Link opencv statically.", default=False
+    )
+
+    args = parser.parse_args()
+
+    build_script(static=args.static or os.environ.get("RUST_STARTRACKER_OPENCV_LINK_STATIC") == "1")


### PR DESCRIPTION
Importing ruststartracker in Python fails if the installed opencv version doesn't match with the one used to build the wheel in the CI. This PR links opencv statically into the .so file, so it is independent on platform opencv shared libaries.

Since only `imgproc` functionality of opencv is used, building opencv from source is quite quick.