### PR TITLE
hotfix: Fixed missing symbols

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,12 @@ jobs:
           -DBUILD_PNG=OFF \
           -DBUILD_TIFF=OFF \
           -DBUILD_WEBP=OFF \
+          -DWITH_ITT=OFF \
+          -DBUILD_ITT=OFF \
+          -DWITH_IPP=OFF \
+          -DWITH_IPPICV=OFF \
+          -DBUILD_IPP_IW=OFF \
+          -DBUILD_WITH_DYNAMIC_IPP=OFF \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=/opt/opencv-static \
           -DCMAKE_POSITION_INDEPENDENT_CODE=ON \


### PR DESCRIPTION
Version 0.2.8 accidently included static builds that missed symbols for ITT/IPP. This MR compiles opencv without them, so they're no longer required.